### PR TITLE
Put secret inside register to match actual sockethub-client syntax

### DIFF
--- a/src/sockethub.js
+++ b/src/sockethub.js
@@ -27,9 +27,16 @@
           "description": "whether or not to use TLS",
           "required": false
         },
-        "secret": {
-          "type": "string",
-          "description": "the secret to identify yourself with the sockethub server",
+        "register": {
+          "description" : "sockethub config file",
+          "type" : "object",
+          "properties": {
+            "secret": {
+              "type": "string",
+              "description": "the secret to identify yourself with the sockethub server",
+              "required": true
+            }
+          },
           "required": true
         }
       }


### PR DESCRIPTION
When giving the config to sockethub-client, the secret should be inside
an object called register, so we might as well store it directly in
that format.
